### PR TITLE
colour the test output via the :colour => true or :color => true option  

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,6 +61,19 @@ You can set minitest verbose mode with:
       ...
     end
 
+You can colour the test output (via minitest/pride) with:
+  (Remark : the "minitest" gem must be installed.)
+
+    guard 'minitest', :colour => true do
+      ...
+    end
+  or
+    guard 'minitest', :color => true do
+      ...
+    end
+
+
+
 You can disable desktop notification with:
 
     guard 'minitest', :notify => false do

--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -17,7 +17,9 @@ module Guard
           :notify   => true,
           :bundler  => File.exist?("#{Dir.pwd}/Gemfile"),
           :rubygems => false,
-          :drb      => false
+          :drb      => false,
+          :colour   => false,
+          :color    => false
         }.merge(options)
       end
 
@@ -51,6 +53,11 @@ module Guard
         @options[:drb]
       end
 
+      def colour?
+        @options[:colour] || @options[:color]
+      end
+      alias color? colour?
+
       private
 
       def minitest_command(paths)
@@ -65,7 +72,8 @@ module Guard
           end
         else
           cmd_parts << 'ruby -Itest -Ispec'
-          cmd_parts << '-r rubygems' if rubygems?
+          cmd_parts << '-rminitest/pride' if colour?
+          cmd_parts << '-r rubygems'      if rubygems?
           cmd_parts << '-r bundler/setup' if bundler?
           paths.each do |path|
             cmd_parts << "-r ./#{path}"

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -94,6 +94,22 @@ describe Guard::Minitest::Runner do
       end
 
     end
+
+    describe 'colour/color' do
+
+      it 'default should be false' do
+        subject.new.colour?.must_equal false
+        subject.new.color? .must_equal false
+      end
+
+      it 'should be set' do
+        subject.new(:colour=> true).colour?.must_equal true
+        subject.new(:colour=> true).color? .must_equal true
+        subject.new(:color => true).colour?.must_equal true
+        subject.new(:color => true).color? .must_equal true
+      end
+
+    end
   end
 
   describe 'run' do
@@ -108,6 +124,24 @@ describe Guard::Minitest::Runner do
       Guard::UI.expects(:info)
       runner.expects(:system).with(
         "ruby -Itest -Ispec -r ./test/test_minitest.rb -r #{@default_runner} -e 'GUARD_NOTIFY=true; MiniTest::Unit.autorun' -- --seed 12345"
+      )
+      runner.run(['test/test_minitest.rb'])
+    end
+
+    it 'should run with specified colour mode' do
+      runner = subject.new(:colour => true)
+      Guard::UI.expects(:info)
+      runner.expects(:system).with(
+        "ruby -Itest -Ispec -rminitest/pride -r ./test/test_minitest.rb -r #{@default_runner} -e 'GUARD_NOTIFY=true; MiniTest::Unit.autorun' --"
+      )
+      runner.run(['test/test_minitest.rb'])
+    end
+
+    it 'should run with specified color mode' do
+      runner = subject.new(:color => true)
+      Guard::UI.expects(:info)
+      runner.expects(:system).with(
+        "ruby -Itest -Ispec -rminitest/pride -r ./test/test_minitest.rb -r #{@default_runner} -e 'GUARD_NOTIFY=true; MiniTest::Unit.autorun' --"
       )
       runner.run(['test/test_minitest.rb'])
     end


### PR DESCRIPTION
colour the test output via the :colour => true or :color => true option  (uses minitest/pride)

note: you must install the 'minitest' gem explicitly.
