### PR TITLE
added rails functional/unit regexps to template Guardfile (commented out)

### DIFF
--- a/lib/guard/minitest/templates/Guardfile
+++ b/lib/guard/minitest/templates/Guardfile
@@ -8,4 +8,8 @@ guard 'minitest' do
   # watch(%r|^spec/(.*)_spec\.rb|)
   # watch(%r|^lib/(.*)\.rb|)            { |m| "spec/#{m[1]}_spec.rb" }
   # watch(%r|^spec/spec_helper\.rb|)    { "spec" }
+
+  # Rails
+  # watch(%r|^app/controllers/(.*)\.rb|) { |m| "test/functional/#{m[1]}_test.rb" }
+  # watch(%r|^app/models/(.*)\.rb|)      { |m| "test/unit/#{m[1]}_test.rb" }
 end


### PR DESCRIPTION
Hi, this adds the ability to watch Rails test files in the template (commented out by default). I only use guard-minitest with Rails and having to refer to my other guardfiles each time (because I'm too lazy to write the regexp) is frustrating. It would be awesome if the template had these defaults ready to be uncommented :)
