### PR TITLE
add a required_files option to add in extra required files

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -51,6 +51,10 @@ module Guard
         @options[:drb]
       end
 
+      def required_files
+        [@options[:require] ||= []].flatten
+      end
+
       private
 
       def minitest_command(paths)
@@ -67,9 +71,15 @@ module Guard
           cmd_parts << 'ruby -Itest -Ispec'
           cmd_parts << '-r rubygems' if rubygems?
           cmd_parts << '-r bundler/setup' if bundler?
+
+          required_files.each do |path|
+            cmd_parts << "-r #{path}"
+          end
+
           paths.each do |path|
             cmd_parts << "-r ./#{path}"
           end
+
           cmd_parts << "-r #{File.expand_path('../runners/default_runner.rb', __FILE__)}"
           if notify?
             cmd_parts << '-e \'GUARD_NOTIFY=true; MiniTest::Unit.autorun\''


### PR DESCRIPTION
Hey all,

I'm running guard and minitest without drb, and I found I needed to explicitly require `spec_helper`.  I've added in a `:require => ...` option that will import whatever libraries are specified.  Does this sound like a reasonable solution?
