### PR TITLE
fixed watch clausule for test unit

### DIFF
--- a/lib/guard/minitest/templates/Guardfile
+++ b/lib/guard/minitest/templates/Guardfile
@@ -1,6 +1,6 @@
 guard 'minitest' do
   # with Minitest::Unit
-  watch(%r|^test/test_(.*)\.rb|)
+  watch(%r|^test/(.*)\/?test_(.*)\.rb|)
   watch(%r|^lib/(.*)([^/]+)\.rb|)     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
   watch(%r|^test/test_helper\.rb|)    { "test" }
 


### PR DESCRIPTION
The previous watch clause for minitest unit only matches test files on root of test folder, this one that I used works also for nested folders.
