### PR TITLE
Support growl notifications even when using spork (:drb => true).

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -58,6 +58,12 @@ module Guard
         cmd_parts << "bundle exec" if bundler?
         if drb?
           cmd_parts << 'testdrb'
+          cmd_parts << "-r #{File.expand_path('../runners/default_runner.rb', __FILE__)}"
+          if notify?
+            cmd_parts << '-e \'::GUARD_NOTIFY=true\''
+          else
+            cmd_parts << '-e \'::GUARD_NOTIFY=false\''
+          end
           cmd_parts << 'test/test_helper.rb' if File.exist?('test/test_helper.rb')
           cmd_parts << 'spec/spec_helper.rb' if File.exist?('spec/spec_helper.rb')
           paths.each do |path|

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -199,7 +199,18 @@ describe Guard::Minitest::Runner do
           File.expects(:exist?).with('test/test_helper.rb').returns(true)
           File.expects(:exist?).with('spec/spec_helper.rb').returns(false)
           runner.expects(:system).with(
-            "testdrb test/test_helper.rb ./test/test_minitest.rb"
+            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb -e '::GUARD_NOTIFY=true' test/test_helper.rb ./test/test_minitest.rb"
+          )
+          runner.run(['test/test_minitest.rb'], :drb => true)
+        end
+
+        it 'should run with drb and notify=false' do
+          runner = subject.new(:drb => true, :notify => false)
+          Guard::UI.expects(:info)
+          File.expects(:exist?).with('test/test_helper.rb').returns(true)
+          File.expects(:exist?).with('spec/spec_helper.rb').returns(false)
+          runner.expects(:system).with(
+            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb -e '::GUARD_NOTIFY=false' test/test_helper.rb ./test/test_minitest.rb"
           )
           runner.run(['test/test_minitest.rb'], :drb => true)
         end
@@ -212,7 +223,18 @@ describe Guard::Minitest::Runner do
           File.expects(:exist?).with('test/test_helper.rb').returns(false)
           File.expects(:exist?).with('spec/spec_helper.rb').returns(true)
           runner.expects(:system).with(
-            "testdrb spec/spec_helper.rb ./test/test_minitest.rb"
+            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb -e '::GUARD_NOTIFY=true' spec/spec_helper.rb ./test/test_minitest.rb"
+          )
+          runner.run(['test/test_minitest.rb'], :drb => true)
+        end
+
+        it 'should run with drb and notify=false' do
+          runner = subject.new(:drb => true, :notify => false)
+          Guard::UI.expects(:info)
+          File.expects(:exist?).with('test/test_helper.rb').returns(false)
+          File.expects(:exist?).with('spec/spec_helper.rb').returns(true)
+          runner.expects(:system).with(
+            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb -e '::GUARD_NOTIFY=false' spec/spec_helper.rb ./test/test_minitest.rb"
           )
           runner.run(['test/test_minitest.rb'], :drb => true)
         end


### PR DESCRIPTION
This fixes Issue #11 (No notification when running with spork server).

**NOTE NOTE NOTE**: this code requires a version of `spork-testunit` that supports the `-r` and `-e` command-line arguments. I have filed [this pull request](https://github.com/sporkrb/spork-testunit/pull/32) in the `spork-testunit` repo, adding support for `-r` and `-e`. 

Please lend your support to the `spork-testunit` pull request in order to enable growl notification when using the spork server with guard-minitest.
