### PR TITLE
Fixes: "uninitialized constant MiniTest::Unit::Guard::MinitestNotifier (NameError)" in 1.9.x

### DIFF
--- a/lib/guard/minitest/runners/version_1_runner.rb
+++ b/lib/guard/minitest/runners/version_1_runner.rb
@@ -10,7 +10,7 @@ module MiniTest
       start = Time.now
       run_without_guard(args)
       duration = Time.now - start
-      Guard::MinitestNotifier.notify(test_count, assertion_count, failures, errors, skips, duration) if GUARD_NOTIFY
+      ::Guard::MinitestNotifier.notify(test_count, assertion_count, failures, errors, skips, duration) if GUARD_NOTIFY
     end
 
   end

--- a/lib/guard/minitest/runners/version_2_runner.rb
+++ b/lib/guard/minitest/runners/version_2_runner.rb
@@ -11,7 +11,7 @@ module MiniTest
         start = Time.now
         _run_anything_without_guard(type)
         duration = Time.now - start
-        Guard::MinitestNotifier.notify(test_count, assertion_count, failures, errors, skips, duration) if GUARD_NOTIFY
+        ::Guard::MinitestNotifier.notify(test_count, assertion_count, failures, errors, skips, duration) if GUARD_NOTIFY
       end
     rescue NameError
       puts "*** WARN: if you use MiniTest 1, please add version option in your 'Guardfile`."


### PR DESCRIPTION
Since updating minitest and guard-minitest Guard raised error on every run.
