### PR TITLE
Watched files with no tests raise an exception.

### DIFF
--- a/lib/guard/minitest/notifier.rb
+++ b/lib/guard/minitest/notifier.rb
@@ -9,7 +9,9 @@ module Guard
       if skip_count > 0
         message << " (#{skip_count} skips)"
       end
-      message << "\nin %.6f seconds, %.4f tests/s, %.4f assertions/s." % [duration, test_count / duration, assertion_count / duration]
+      if test_count && assertion_count
+        message << "\nin %.6f seconds, %.4f tests/s, %.4f assertions/s." % [duration, test_count / duration, assertion_count / duration]
+      end
       message
     end
 


### PR DESCRIPTION
If no tests are run, there's no point trying to print this message. If installed guard-minitest off my branch, and this is working fine. :-)
