### PR TITLE
Simplifying the DRb version of the runner

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -66,11 +66,6 @@ module Guard
         cmd_parts << "bundle exec" if bundler?
         if drb?
           cmd_parts << 'testdrb'
-          cmd_parts << "-r #{File.expand_path('../runners/default_runner.rb', __FILE__)}"
-          test_folders.each do |f|
-            cmd_parts << "#{f}/test_helper.rb" if File.exist?("#{f}/test_helper.rb")
-            cmd_parts << "#{f}/spec_helper.rb" if File.exist?("#{f}/spec_helper.rb")
-          end
           cmd_parts += paths.map{ |path| "./#{path}" }
         else
           cmd_parts << 'ruby'

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -163,74 +163,13 @@ describe Guard::Minitest::Runner do
     end
 
     describe 'drb' do
-      describe 'when using test_helper' do
-        it 'should run with drb' do
-          runner = subject.new(:test_folders => %w[test], :drb => true)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('test/test_helper.rb').returns(true)
-          File.expects(:exist?).with('test/spec_helper.rb').returns(false)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb test/test_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
-
-        it 'should run with drb and notification disable' do
-          runner = subject.new(:test_folders => %w[test], :drb => true, :notification => false)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('test/test_helper.rb').returns(true)
-          File.expects(:exist?).with('test/spec_helper.rb').returns(false)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb test/test_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
-
-        it 'should run with drb and notification enable' do
-          runner = subject.new(:test_folders => %w[test], :drb => true, :notification => true)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('test/test_helper.rb').returns(true)
-          File.expects(:exist?).with('test/spec_helper.rb').returns(false)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb test/test_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
-      end
-
-      describe 'when using spec_helper' do
-        it 'should run with drb' do
-          runner = subject.new(:test_folders => %w[spec], :drb => true)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('spec/test_helper.rb').returns(false)
-          File.expects(:exist?).with('spec/spec_helper.rb').returns(true)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb spec/spec_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
-
-        it 'should run with drb and notification disabled' do
-          runner = subject.new(:test_folders => %w[spec], :drb => true, :notification => false)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('spec/test_helper.rb').returns(false)
-          File.expects(:exist?).with('spec/spec_helper.rb').returns(true)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb spec/spec_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
-
-        it 'should run with drb and notification enabled' do
-          runner = subject.new(:test_folders => %w[spec], :drb => true, :notification => true)
-          Guard::UI.expects(:info)
-          File.expects(:exist?).with('spec/test_helper.rb').returns(false)
-          File.expects(:exist?).with('spec/spec_helper.rb').returns(true)
-          runner.expects(:system).with(
-            "testdrb -r #{File.expand_path('.')}/lib/guard/minitest/runners/default_runner.rb spec/spec_helper.rb ./test/test_minitest.rb"
-          )
-          runner.run(['test/test_minitest.rb'], :drb => true)
-        end
+      it 'should run with drb' do
+        runner = subject.new(:test_folders => %w[test], :drb => true)
+        Guard::UI.expects(:info)
+        runner.expects(:system).with(
+          "testdrb ./test/test_minitest.rb"
+        )
+        runner.run(['test/test_minitest.rb'], :drb => true)
       end
     end
   end


### PR DESCRIPTION
We're using guard-minitest with [spork-minitest](https://github.com/semaperepelitsa/spork-minitest). Spork works when running just `spork` and then using `testdrb` to run individual files, but guard-minitest was broken. It kept saying

```
Running tests with args ["-r", "/Users/costro0001/.rvm/gems/ruby-1.9.2-p180-patched/gems/guard-minitest-0.5.0/lib/guard/minitest/runners/default_runner.rb", "-e
", "::GUARD_NOTIFY=true", "test/test_helper.rb", "./test/unit/raw_site_test.rb"]...
Exception encountered: #<LoadError: no such file to load -- -r>
```

It turns out that the [implementation of testdrb in spork-minitest](https://github.com/semaperepelitsa/spork-minitest/blob/master/bin/testdrb) does not allow the `-r` or `-e` options in the way guard-minitest had been passing them in. Additionally, I found that the inclusion of test_helper/spec_helper was also unnecessary, as these files were already being included in the individual test that was being run.

I'm not sure why all of this extra machinery was in place. It seems strange that I just removed it. Let me know what you think.
