### PR TITLE
Set GUARD_NOTIFY in non-drb runs

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -86,7 +86,7 @@ module Guard
           cmd_parts << '-r bundler/setup' if bundler?
           cmd_parts += paths.map{|path| "-r ./#{path}" }
           cmd_parts << "-r #{File.expand_path('../runners/default_runner.rb', __FILE__)}"
-          cmd_parts << '-e \'MiniTest::Unit.autorun\''
+          cmd_parts << "-e '::GUARD_NOTIFY=#{notify?}; MiniTest::Unit.autorun'"
           cmd_parts << '--' << cli_options unless cli_options.empty?
         end
 

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -99,7 +99,7 @@ describe Guard::Minitest::Runner do
       runner = subject.new(:test_folders => %w[test], :seed => 12345)
       Guard::UI.expects(:info)
       runner.expects(:system).with(
-        "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun' --  --seed 12345"
+        "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun' --  --seed 12345"
       )
       runner.run(['test/test_minitest.rb'])
     end
@@ -108,7 +108,7 @@ describe Guard::Minitest::Runner do
       runner = subject.new(:test_folders => %w[test], :verbose => true)
       Guard::UI.expects(:info)
       runner.expects(:system).with(
-        "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun' --  --verbose"
+        "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun' --  --verbose"
       )
       runner.run(['test/test_minitest.rb'])
     end
@@ -123,7 +123,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test])
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun'"
+          "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun'"
         )
         runner.run(['test/test_minitest.rb'])
       end
@@ -132,7 +132,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test], :rubygems => true)
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "ruby -I\"test\" -r rubygems -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun'"
+          "ruby -I\"test\" -r rubygems -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun'"
         )
         runner.run(['test/test_minitest.rb'])
       end
@@ -149,7 +149,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test], :bundler => true, :rubygems => false)
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "bundle exec ruby -I\"test\" -r bundler/setup -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun'"
+          "bundle exec ruby -I\"test\" -r bundler/setup -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun'"
         )
         runner.run(['test/test_minitest.rb'])
       end
@@ -158,7 +158,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test], :bundler => false, :rubygems => true)
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "ruby -I\"test\" -r rubygems -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun'"
+          "ruby -I\"test\" -r rubygems -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun'"
         )
         runner.run(['test/test_minitest.rb'], :bundler => false, :rubygems => true)
       end
@@ -167,7 +167,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test], :bundler => false, :rubygems => false)
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e 'MiniTest::Unit.autorun'"
+          "ruby -I\"test\" -r ./test/test_minitest.rb -r #{@default_runner} -e '::GUARD_NOTIFY=false; MiniTest::Unit.autorun'"
         )
         runner.run(['test/test_minitest.rb'], :bundler => false, :rubygems => false)
       end


### PR DESCRIPTION
Readding the declaration of GUARD_NOTIFY in the execution command after
it was removed in 60d71f418be24d995088eeb8dbaba8800fd4cad3. Otherwise
the runner blows up because it can't find GUARD_NOTIFY when going to
invoke Guard::MinitestNotifier. (See version_2_runner.rb line 14)
