### PR TITLE
Guard 1.1 compatibility

### DIFF
--- a/guard-minitest.gemspec
+++ b/guard-minitest.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'guard-minitest'
 
-  s.add_dependency 'guard', '~> 1.0'
+  s.add_dependency 'guard', '~> 1.1'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest',  '~> 2.1'

--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -33,7 +33,7 @@ module Guard
       true
     end
 
-    def run_on_change(paths = [])
+    def run_on_changes(paths = [])
       paths = @inspector.clean(paths)
       return @runner.run(paths) unless paths.empty?
       true

--- a/spec/guard/minitest_spec.rb
+++ b/spec/guard/minitest_spec.rb
@@ -66,12 +66,12 @@ describe Guard::Minitest do
 
   end
 
-  describe 'run_on_change' do
+  describe 'run_on_changes' do
 
     it 'should run minitest in paths' do
       inspector.stubs(:clean).with(['test/guard/minitest/test_inspector.rb']).returns(['test/guard/minitest/test_inspector.rb'])
       runner.expects(:run).with(['test/guard/minitest/test_inspector.rb']).returns(true)
-      guard.run_on_change(['test/guard/minitest/test_inspector.rb']).must_equal true
+      guard.run_on_changes(['test/guard/minitest/test_inspector.rb']).must_equal true
     end
 
   end


### PR DESCRIPTION
Bumped required guard version in gemspec. Also, renamed
Guard::Minitest#run_on_change to run_on_changes to eliminate deprecation
warning.
