### PR TITLE
Add option to run all tests on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ end
 :drb => true                # enable DRb support, default: false
 :test_folders => ['tests']  # specify an array of paths that contain test files, default: %w[test spec]
 :test_file_patterns => true # specify an array of patterns that test files must match in order to be run, default: %w[*_test.rb test_*.rb *_spec.rb]
+:all_on_start => true       # run all tests in group on startup, default: false
 ```
 
 Development

--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -13,6 +13,9 @@ module Guard
 
       @runner = Runner.new(options)
       @inspector = Inspector.new(@runner.test_folders, @runner.test_file_patterns)
+      if options[:all_on_start]
+        run_all
+      end
     end
 
     def start

--- a/spec/guard/minitest_spec.rb
+++ b/spec/guard/minitest_spec.rb
@@ -25,6 +25,11 @@ describe Guard::Minitest do
       subject.new
     end
 
+    it 'should run all tests if you pass options[:run_all_on_start]' do
+      subject.any_instance.expects(:run_all)
+      subject.new([], {all_on_start: true})
+    end
+
     it 'should initialize inspector with options' do
       Guard::Minitest::Inspector.expects(:new).with(runner.test_folders, runner.test_file_patterns).returns(inspector)
       subject.new


### PR DESCRIPTION
I liked this feature in guard-rspec, so I added it. Works and is tested, also updated the readme.
