### PR TITLE
Include test directory in load path

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -65,7 +65,7 @@ module Guard
 
         cmd_parts << "bundle exec" if bundler?
         if drb?
-          cmd_parts << 'testdrb'
+          cmd_parts << 'testdrb -Itest'
           cmd_parts += paths.map{ |path| "./#{path}" }
         else
           cmd_parts << 'ruby'

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -167,7 +167,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(:test_folders => %w[test], :drb => true)
         Guard::UI.expects(:info)
         runner.expects(:system).with(
-          "testdrb ./test/test_minitest.rb"
+          "testdrb -Itest ./test/test_minitest.rb"
         )
         runner.run(['test/test_minitest.rb'], :drb => true)
       end


### PR DESCRIPTION
Because Rails-generated tests start with `require 'test_helper'`, we need to include the test directory in the load path.

Without this patch, auto-generated tests fail with:

```
test/unit/user_test.rb:1:in `require': cannot load such file -- test_helper (LoadError)
    from test/unit/user_test.rb:1:in `<main>'
```

The alternative is to ask every user to change to `require_relative`, and I assert that users should not have to change your tests for them to work with Guard.
