### PR TITLE
Use Minitest::StatisticsReporter instead of Reporter

### DIFF
--- a/lib/guard/minitest/reporter.rb
+++ b/lib/guard/minitest/reporter.rb
@@ -4,18 +4,14 @@ require 'guard/minitest/notifier'
 
 module Guard
   class Minitest
-    class Reporter < ::Minitest::Reporter
+    class Reporter < ::Minitest::StatisticsReporter
 
       def report
-        aggregate = results.group_by { |r| r.failure.class }
-        aggregate.default = [] # dumb. group_by should provide this
+        super
 
-        f = aggregate[::Minitest::Assertion].size
-        e = aggregate[::Minitest::UnexpectedError].size
-        s = aggregate[::Minitest::Skip].size
-        t = Time.now - start_time
-
-        ::Guard::Minitest::Notifier.notify(count, self.assertions, f, e, s, t)
+        ::Guard::Minitest::Notifier.notify(self.count, self.assertions,
+                                           self.failures, self.errors,
+                                           self.skips, self.total_time)
       end
 
     end

--- a/lib/guard/minitest/reporters/old_reporter.rb
+++ b/lib/guard/minitest/reporters/old_reporter.rb
@@ -1,0 +1,23 @@
+# encoding: utf-8
+require 'minitest'
+require 'guard/minitest/notifier'
+
+module Guard
+  class Minitest
+    class Reporter < ::Minitest::Reporter
+
+      def report
+        aggregate = results.group_by { |r| r.failure.class }
+        aggregate.default = [] # dumb. group_by should provide this
+
+        f = aggregate[::Minitest::Assertion].size
+        e = aggregate[::Minitest::UnexpectedError].size
+        s = aggregate[::Minitest::Skip].size
+        t = Time.now - start_time
+
+        ::Guard::Minitest::Notifier.notify(count, self.assertions, f, e, s, t)
+      end
+
+    end
+  end
+end

--- a/lib/minitest/guard_minitest_plugin.rb
+++ b/lib/minitest/guard_minitest_plugin.rb
@@ -1,4 +1,8 @@
-require 'guard/minitest/reporter'
+if ::MiniTest::Unit::VERSION =~ /^5/
+  require 'guard/minitest/reporter'
+else
+  require 'guard/minitest/reporters/old_reporter'
+end
 
 module Minitest
   def self.plugin_guard_minitest_options(opts, options) # :nodoc:


### PR DESCRIPTION
I was getting the following error on `master`:

```
$ be rake test                                                                                         
[Coveralls] Outside the Travis environment, not sending data.                                          
Run options: --seed 64029                                                                              

# Running:                                                                                             

......................................................                                                 

Finished in 0.130653s, 413.3085 runs/s, 543.4242 assertions/s.                                         

54 runs, 71 assertions, 0 failures, 0 errors, 0 skips                                                  
/.../guard-minitest/lib/guard/minitest/reporter.rb:10:in `report': undefined local variable or method `results' for #<Guard::Minitest::Reporter:0x007fc491f5f278> (NameError)       
        from /.../guard-minitest/.bundle/gems/minitest-5.0.4/lib/minitest.rb:
584:in `each'                                                                                          
        from /.../guard-minitest/.bundle/gems/minitest-5.0.4/lib/minitest.rb:
584:in `report'                                                                                        
        from /.../guard-minitest/.bundle/gems/minitest-5.0.4/lib/minitest.rb:
114:in `run'                                                                                           
        from /.../guard-minitest/.bundle/gems/minitest-5.0.4/lib/minitest.rb:
46:in `block in autorun'                                                                               
```

Fixed by inheriting from `StatisticsReporter` instead of `Reporter`. I'd be happy to add a spec for this, but wasn't sure how to best implement it.
