### PR TITLE
fix NameError in Reporter with minitest 5.0.4

### DIFF
--- a/lib/guard/minitest/reporter.rb
+++ b/lib/guard/minitest/reporter.rb
@@ -4,7 +4,9 @@ require 'guard/minitest/notifier'
 
 module Guard
   class Minitest
-    class Reporter < ::Minitest::Reporter
+    # NB: Minitest 5.0.4 uses ::Minitest:;StatisticsReporter; older minitest uses ::Minitest::Reporter
+    parent_class = defined?(::Minitest::StatisticsReporter) ? ::Minitest::StatisticsReporter : ::Minitest::Reporter
+    class Reporter < parent_class
 
       def report
         aggregate = results.group_by { |r| r.failure.class }


### PR DESCRIPTION
Minitest 5.0.4 moved the #results method from the Reporter class to
StatisticsReporter.

Guard::Minitest::Reporter uses StatisticsReporter if available, falls
back to Reporter for older minitest versions
