### PR TITLE
Referencing the correct Minitest object

### DIFF
--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -51,7 +51,7 @@ module Guard
 
       rescue LoadError, NameError
         require 'minitest/unit'
-        ::MiniTest::Unit::VERSION
+        ::Minitest::Unit::VERSION
       end
     end
 


### PR DESCRIPTION
The camelCased reference of MiniTest from 3fae806de5b4501e164f0eb73c3894ab8dbf832a wasn't defined and was causing Guard to fire `Guard::Minitest`.
