### PR TITLE
Allow specifying arbitrary include paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ end
 :all_on_start => false      # run all tests in group on startup, default: true
 :cli => '--test'            # pass arbitrary Minitest CLI arguments, default: ''
 :test_folders => ['tests']  # specify an array of paths that contain test files, default: %w[test spec]
+:include => ['lib']         # specify an array of include paths to the command that runs the tests
 :test_file_patterns => true # specify an array of patterns that test files must match in order to be run, default: %w[*_test.rb test_*.rb *_spec.rb]
 :spring => true             # enable spring support, default: false
 :zeus => true               # enable zeus support; default: false

--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -16,6 +16,7 @@ module Guard
           :drb                => false,
           :zeus               => false,
           :spring             => false,
+          :include            => [],
           :test_folders       => %w[test spec],
           :test_file_patterns => %w[*_test.rb test_*.rb *_spec.rb],
           :cli                => nil
@@ -62,6 +63,10 @@ module Guard
         @options[:test_folders]
       end
 
+      def include_folders
+        @options[:include]
+      end
+
       def test_file_patterns
         @options[:test_file_patterns]
       end
@@ -104,7 +109,7 @@ module Guard
 
       def ruby_command(paths)
         cmd_parts  = ['ruby']
-        cmd_parts.concat(test_folders.map {|f| %[-I"#{f}"] })
+        cmd_parts.concat(generate_includes)
         cmd_parts << '-r rubygems' if rubygems?
         cmd_parts << '-r bundler/setup' if bundler?
         cmd_parts << '-r minitest/autorun'
@@ -122,6 +127,10 @@ module Guard
 
         cmd_parts << '--'
         cmd_parts += cli_options
+      end
+
+      def generate_includes
+        (test_folders + include_folders).map {|f| %[-I"#{f}"] }
       end
 
       def relative_paths(paths)

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -136,6 +136,15 @@ describe Guard::Minitest::Runner do
       runner.run(['test/test_minitest.rb'])
     end
 
+    it 'should run with specified directories included' do
+      runner = subject.new(:test_folders => %w[test], :include => %w[lib app])
+      runner.expects(:system).with(
+        "ruby -I\"test\" -I\"lib\" -I\"app\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+      )
+
+      runner.run(['test/test_minitest.rb'])
+    end
+
     it 'should run in verbose mode' do
       runner = subject.new(:test_folders => %w[test], :cli => '--verbose')
       runner.expects(:system).with(


### PR DESCRIPTION
guard-minitest already allows specifying `test_folders`, but those are also used for filtering test files, so if one wanted to add `test` to include paths, but only run tests from under `test/unit`, it would not be possible with the current options.

This pull request adds a secondary `:include` option, akin to the one that [guard-test](https://github.com/guard/guard-test) uses.
