### PR TITLE
Clears memoized test files on additions and removals

### DIFF
--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -42,6 +42,15 @@ module Guard
       @runner.run(paths)
     end
 
+    def run_on_additions(paths)
+      @inspector.clear_memoized_test_files
+      @runner.run(paths)
+    end
+
+    def run_on_removals(paths)
+      @inspector.clear_memoized_test_files
+    end
+
     private
 
     def _minitest_version

--- a/lib/guard/minitest/inspector.rb
+++ b/lib/guard/minitest/inspector.rb
@@ -25,6 +25,10 @@ module Guard
         end.uniq
       end
 
+      def clear_memoized_test_files
+        @_all_test_files = nil
+      end
+
       private
 
       def _test_files_for_paths(paths = test_folders)

--- a/spec/guard/minitest_spec.rb
+++ b/spec/guard/minitest_spec.rb
@@ -77,4 +77,27 @@ describe Guard::Minitest do
       subject.new.run_on_changes(['test/guard/minitest/test_inspector.rb']).must_equal true
     end
   end
+
+  describe 'run_on_additions' do
+    it 'clears the test file cache and runs minitest for the new path' do
+      inspector.stubs(:clean).with(['test/guard/minitest/test_new.rb']).returns(['test/guard/minitest/test_new.rb'])
+
+      inspector.expects(:clear_memoized_test_files)
+      runner.expects(:run).with(['test/guard/minitest/test_new.rb']).returns(true)
+
+      subject.new.run_on_additions(['test/guard/minitest/test_new.rb']).must_equal true
+    end
+  end
+
+  describe 'run_on_removals' do
+    it 'clears the test file cache and does not run minitest' do
+      inspector.stubs(:clean).with(['test/guard/minitest/test_deleted.rb']).returns(['test/guard/minitest/test_deleted.rb'])
+
+      inspector.expects(:clear_memoized_test_files)
+      runner.expects(:run).never
+
+      subject.new.run_on_removals(['test/guard/minitest/test_deleted.rb'])
+    end
+
+  end
 end


### PR DESCRIPTION
Like discussed in #80, this makes sure added files are picked up and removed files won't be tested in subsequent runs any longer (thus preventing the file not found errors).
