### PR TITLE
Shelling out with clean env when not using bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvement
 
+* [#84][] Fix bug with spring (and maybe zeus) where it had to be included in an app's Gemfile. ([@brandonweiss][])
 * #83 Add note for Rails projects using profile/benchmark tests in README. ([@rymai][])
 
 ## 1.3.0 - Sept 12, 2013

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -258,6 +258,28 @@ describe Guard::Minitest::Runner do
           Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', :title => 'Minitest results', :image => :failed)
           runner.run(['test/test_minitest.rb'], :zeus => true)
         end
+
+        it 'should provide success notification when the spring exit status is 0' do
+          runner = subject.new(:test_folders => %w[test], :spring => true)
+
+          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(true)
+          Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', :title => 'Minitest results', :image => :success)
+          runner.run(['test/test_minitest.rb'], :spring => true)
+        end
+
+        it 'should provide failed notification when the spring exit status is non-zero or the command failed' do
+          runner = subject.new(:test_folders => %w[test], :spring => true)
+
+          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(false)
+          Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', :title => 'Minitest results', :image => :failed)
+          runner.run(['test/test_minitest.rb'], :spring => true)
+
+          runner = subject.new(:test_folders => %w[test], :spring => true)
+
+          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(false)
+          Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', :title => 'Minitest results', :image => :failed)
+          runner.run(['test/test_minitest.rb'], :spring => true)
+        end
       end
     end
 
@@ -265,6 +287,15 @@ describe Guard::Minitest::Runner do
       it 'should run with default spring command' do
         runner = subject.new(:test_folders => %w[test], :spring => true)
         Guard::UI.expects(:info)
+        runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb")
+
+        runner.run(['test/test_minitest.rb'], :spring => true)
+      end
+
+      it "should run with a clean environment" do
+        runner = subject.new(:test_folders => %w[test], :spring => true)
+        Guard::UI.expects(:info)
+        Bundler.expects(:with_clean_env).yields
         runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb")
 
         runner.run(['test/test_minitest.rb'], :spring => true)


### PR DESCRIPTION
Even with the `bundler` option set to false (or negated by the `zeus` or
`spring` options), if Bundler has been loaded prior to shelling out, it
somehow alters/infects the new environment. The solution is to wrap
the logic in a `Bundler.with_clean_env` block.

Also notifying guard with success/fail for spring as well as zeus.
