### PR TITLE
No need to check for bundler? if checking for defined?(::Bundlier)

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -33,17 +33,13 @@ module Guard
         message = options[:message] || "Running: #{paths.join(' ')}"
         UI.info message, reset: true
 
-        status = if bundler?
-          system(minitest_command(paths))
-        else
-          if defined?(::Bundler)
-            ::Bundler.with_clean_env do
-              system(minitest_command(paths))
-            end
-          else
-            system(minitest_command(paths))
-          end
-        end
+        status = if defined?(::Bundler)
+                   ::Bundler.with_clean_env do
+                     system(minitest_command(paths))
+                   end
+                 else
+                   system(minitest_command(paths))
+                 end
 
         # When using zeus or spring, the Guard::Minitest::Reporter can't be used because the minitests run in another
         # process, but we can use the exit status of the client process to distinguish between :success and :failed.


### PR DESCRIPTION
Did not use bundler in a project and got hit with a could not find Bundler exception. Saw the error was fixed in HEAD but the logic was a bit confusing so refactored it a bit. Did not add any new specs but no existing specs fail.
