### PR TITLE
Fix spring paths

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -118,11 +118,10 @@ module Guard
         command = @options[:spring].is_a?(String) ? @options[:spring] : 'testunit'
         cmd_parts = ['spring', command]
         cmd_parts << File.expand_path('../runners/old_runner.rb', __FILE__) unless minitest_version_gte_5?
-
         if cli_options.length > 0
-          cmd_parts + relative_paths(paths) + ['--'] + cli_options
+          cmd_parts + paths + ['--'] + cli_options
         else
-          cmd_parts + relative_paths(paths)
+          cmd_parts + paths
         end
       end
 

--- a/spec/guard/minitest/runner_spec.rb
+++ b/spec/guard/minitest/runner_spec.rb
@@ -257,7 +257,7 @@ describe Guard::Minitest::Runner do
         it 'provides success notification when the spring exit status is 0' do
           runner = subject.new(spring: true)
 
-          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(true)
+          runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb").returns(true)
           Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :success)
           runner.run(['test/test_minitest.rb'], spring: true)
         end
@@ -265,13 +265,13 @@ describe Guard::Minitest::Runner do
         it 'provides failed notification when the spring exit status is non-zero or the command failed' do
           runner = subject.new(spring: true)
 
-          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(false)
+          runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb").returns(false)
           Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
           runner.run(['test/test_minitest.rb'], spring: true)
 
           runner = subject.new(spring: true)
 
-          runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb").returns(false)
+          runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb").returns(false)
           Guard::Notifier.expects(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
           runner.run(['test/test_minitest.rb'], spring: true)
         end
@@ -282,7 +282,7 @@ describe Guard::Minitest::Runner do
       it 'runs with default spring command' do
         runner = subject.new(spring: true)
         Guard::UI.expects(:info)
-        runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb")
+        runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb")
 
         runner.run(['test/test_minitest.rb'], spring: true)
       end
@@ -291,7 +291,7 @@ describe Guard::Minitest::Runner do
         runner = subject.new(spring: true)
         Guard::UI.expects(:info)
         Bundler.expects(:with_clean_env).yields
-        runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb")
+        runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb")
 
         runner.run(['test/test_minitest.rb'], spring: true)
       end
@@ -299,21 +299,21 @@ describe Guard::Minitest::Runner do
       it 'runs with custom spring command' do
         runner = subject.new(spring: 'rake test')
         Guard::UI.expects(:info)
-        runner.expects(:system).with("spring rake test#{@old_runner} ./test/test_minitest.rb")
+        runner.expects(:system).with("spring rake test#{@old_runner} test/test_minitest.rb")
         runner.run(['test/test_minitest.rb'], spring: 'rake test')
       end
 
       it 'runs default spring command with cli' do
         runner = subject.new(spring: true, cli: '--seed 12345 --verbose')
         Guard::UI.expects(:info)
-        runner.expects(:system).with("spring testunit#{@old_runner} ./test/test_minitest.rb -- --seed 12345 --verbose")
+        runner.expects(:system).with("spring testunit#{@old_runner} test/test_minitest.rb -- --seed 12345 --verbose")
         runner.run(['test/test_minitest.rb'], spring: true, cli: '--seed 12345 --verbose')
       end
 
       it 'runs custom spring command with cli' do
         runner = subject.new(spring: 'rake test', cli: '--seed 12345 --verbose')
         Guard::UI.expects(:info)
-        runner.expects(:system).with("spring rake test#{@old_runner} ./test/test_minitest.rb -- --seed 12345 --verbose")
+        runner.expects(:system).with("spring rake test#{@old_runner} test/test_minitest.rb -- --seed 12345 --verbose")
         runner.run(['test/test_minitest.rb'], spring: 'rake test', cli: '--seed 12345 --verbose')
       end
     end


### PR DESCRIPTION
Spring shouldn't use relative_paths,  if use relative_paths, when modify a file, will run `spring rake test ./test/models/post_test.rb` or `spring testunit ./test/models/post_test.rb`, it would run all test files.
