### PR TITLE
Prevent tests running multiple times

### DIFF
--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -44,7 +44,7 @@ module Guard
 
     def run_on_additions(paths)
       @inspector.clear_memoized_test_files
-      @runner.run(paths)
+      true
     end
 
     def run_on_removals(paths)

--- a/spec/lib/guard/minitest_spec.rb
+++ b/spec/lib/guard/minitest_spec.rb
@@ -82,7 +82,6 @@ describe Guard::Minitest do
       inspector.stubs(:clean).with(['test/guard/minitest/test_new.rb']).returns(['test/guard/minitest/test_new.rb'])
 
       inspector.expects(:clear_memoized_test_files)
-      runner.expects(:run).with(['test/guard/minitest/test_new.rb']).returns(true)
 
       subject.new.run_on_additions(['test/guard/minitest/test_new.rb']).must_equal true
     end


### PR DESCRIPTION
When saving files with Vim on linux, tests are being run twice.

As seen in several Guard plugins, `run_on_changes` is running multiple times when saving files with Vim. This can be easily remedied by using `run_on_modifications` instead.

See:

guard/guard#297
guard/guard#495

The `run_on_additions` method is also being called when saving files with Vim, causing multiple invocations of the test(s). Because `run_on_modifications` is executed when a new file is created anyway, it should be unnecessary to run the tests explicitly from `run_on_additions`.
