### PR TITLE
Add a `encoding` declaration to the gemspec

### DIFF
--- a/guard-minitest.gemspec
+++ b/guard-minitest.gemspec
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 $:.push File.expand_path('../lib', __FILE__)
 require 'guard/minitest/version'
 


### PR DESCRIPTION
Whenever I ran bundler, I got this exception: 

``` bash
/usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/ui.rb:114:in `[]': invalid byte sequence in US-ASCII (ArgumentError)
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/ui.rb:114:in `strip_leading_spaces'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/ui.rb:119:in `word_wrap'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/ui.rb:105:in `tell_me'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/ui.rb:56:in `error'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/friendly_errors.rb:5:in `rescue in with_friendly_errors'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
    from /usr/local/opt/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/bundler-1.3.5/bin/bundle:20:in `<top (required)>'
    from ./bin/bundle:3:in `load'
    from ./bin/bundle:3:in `<main>'
```

This PR should fix this issue.
