### PR TITLE
Add support for guard halt_on_fail

### DIFF
--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -32,11 +32,11 @@ module Guard
     end
 
     def run_all
-      runner.run_all
+      throw_on_failed_tests { runner.run_all }
     end
 
     def run_on_modifications(paths = [])
-      runner.run_on_modifications(paths)
+      throw_on_failed_tests { runner.run_on_modifications(paths) }
     end
 
     def run_on_additions(paths)
@@ -45,6 +45,12 @@ module Guard
 
     def run_on_removals(paths)
       runner.run_on_removals(paths)
+    end
+
+    private
+
+    def throw_on_failed_tests
+      throw :task_has_failed unless yield
     end
 
   end

--- a/spec/lib/guard/minitest_spec.rb
+++ b/spec/lib/guard/minitest_spec.rb
@@ -42,8 +42,7 @@ describe Guard::Minitest do
 
   describe 'run_on_modifications' do
     it 'is run through runner' do
-      runner.any_instance.expects(:run_on_modifications)
-
+      runner.any_instance.expects(:run_on_modifications => true)
       guard.run_on_modifications
     end
   end
@@ -68,4 +67,17 @@ describe Guard::Minitest do
     end
   end
 
+  describe 'halting and throwing on test failure' do
+    it 'throws on failed test run' do
+      stubbed_runner = stub
+      stubbed_runner.stubs(:run).returns(false)
+      stubbed_runner.expects(:run_all)
+      stubbed_runner.expects(:run_on_modifications)
+
+      guard.runner = stubbed_runner
+
+      proc { guard.run_all }.must_throw :task_has_failed
+      proc { guard.run_on_modifications }.must_throw :task_has_failed
+    end
+  end
 end


### PR DESCRIPTION
When using guard groups, sometimes it's nice to stop other guards from running during the red-green-refactor cycle when the tests are not passing.

This pull request adds the ability to use guard-minitest in such manner, as to be able to configure it like:

``` ruby
group :red_green, :halt_on_fail => true do
  # guard minitest config

  # other guards
end
```
