### PR TITLE
Honor the :include option when running with :drb

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ guard :minitest, drb: true do
   # ...
 end
 ```
+The drb test runner honors the :include option, but does not (unlike the
+default runner) automatically include :test_folders.  If you want to
+include the test paths, you must explicitly add them to :include.
 
 ## Development
 

--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -154,7 +154,7 @@ module Guard
       end
 
       def drb_command(paths)
-        %w[testdrb] + relative_paths(paths)
+        %w[testdrb] + generate_includes(false) + relative_paths(paths)
       end
 
       def zeus_command(paths)
@@ -195,8 +195,14 @@ module Guard
         cmd_parts += cli_options
       end
 
-      def generate_includes
-        (test_folders + include_folders).map {|f| %[-I"#{f}"] }
+      def generate_includes(include_test_folders = true)
+        if include_test_folders
+          folders = test_folders + include_folders
+        else
+          folders = include_folders
+        end
+        
+        folders.map {|f| %[-I"#{f}"] }
       end
 
       def generate_env(all=false)

--- a/spec/lib/guard/minitest/runner_spec.rb
+++ b/spec/lib/guard/minitest/runner_spec.rb
@@ -439,6 +439,16 @@ describe Guard::Minitest::Runner do
 
         runner.run(['test/test_minitest.rb'])
       end
+
+      it 'runs with specified directories included' do
+        runner = subject.new(drb: true, include: %w[lib app])
+
+        runner.expects(:system).with(
+                                     "testdrb -I\"lib\" -I\"app\" ./test/test_minitest.rb"
+                                     )
+        
+        runner.run(['test/test_minitest.rb'])
+      end
     end
   end
 


### PR DESCRIPTION
In the existing code, the drb test runner did not honor the :include option, so this commit adds it in.

In deference to 1f76e, which removed the automatic inclusion of test folders from the drb runner because it was breaking spork-minitest (Issue #72), the commit maintains the existing behavior of the drb runner and does not include :test_folders by default. They can still be expressly included by putting them in :include.
