### PR TITLE
Expand paths before checking for equality

### DIFF
--- a/lib/guard/minitest/inspector.rb
+++ b/lib/guard/minitest/inspector.rb
@@ -43,7 +43,8 @@ module Guard
       end
 
       def _test_file?(path)
-        _test_files_for_paths.include?(path)
+        _test_files_for_paths.map {|path| File.expand_path(path) }
+                             .include?(File.expand_path(path))
       end
 
       def _join_for_glob(fragments)

--- a/spec/lib/guard/minitest/inspector_spec.rb
+++ b/spec/lib/guard/minitest/inspector_spec.rb
@@ -43,5 +43,10 @@ RSpec.describe Guard::Minitest::Inspector do
     it 'should not include test files not in the given dir' do
       expect(inspector.clean(['spec/guard/minitest'])).to_not include 'spec/guard/minitest_spec.rb'
     end
+
+    it 'should include test files in the root dir' do
+      inspector = Guard::Minitest::Inspector.new(%w[.], %w[*.md])
+      expect(inspector.clean(['README.md'])).to eq ['README.md']
+    end
   end
 end


### PR DESCRIPTION
For small projects, sometimes I want to work in a single folder without nesting `lib` or `test` dirs, but I found that `guard-minitest` wouldn't pick up file modifications when working this way (setting `test_folders` to `%w[.]`).