### PR TITLE
Update project to use Guard::Compat > 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ matrix:
 gemfile:
   - gemfiles/Gemfile.minitest-4
   - gemfiles/Gemfile.minitest-5
+
+# use Travis AUFS containers
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,10 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec development_group: :gem_build_deps
 
-gem 'rake'
+group :gem_build_deps do
+  gem 'rake'
+end
 
 group :development do
   gem 'ruby_gntp', require: false

--- a/guard-minitest.gemspec
+++ b/guard-minitest.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_runtime_dependency 'guard',    '~> 2.0'
-  s.add_runtime_dependency 'guard-compat', '~> 0.2'
+  s.add_runtime_dependency 'guard-compat', '~> 1.2'
   s.add_runtime_dependency 'minitest', '>= 3.0'
 
   s.add_development_dependency 'bundler'

--- a/lib/guard/minitest.rb
+++ b/lib/guard/minitest.rb
@@ -18,7 +18,7 @@ module Guard
     end
 
     def start
-      UI.info "Guard::Minitest #{MinitestVersion::VERSION} is running, with Minitest::Unit #{Utils.minitest_version}!"
+      Compat::UI.info "Guard::Minitest #{MinitestVersion::VERSION} is running, with Minitest::Unit #{Utils.minitest_version}!"
       run_all if @options[:all_on_start]
     end
 

--- a/lib/guard/minitest/inspector.rb
+++ b/lib/guard/minitest/inspector.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Inspector
 
       attr_reader :test_folders, :test_file_patterns

--- a/lib/guard/minitest/notifier.rb
+++ b/lib/guard/minitest/notifier.rb
@@ -1,5 +1,3 @@
-require 'guard/notifier'
-
 module Guard
   class Minitest
     class Notifier
@@ -31,7 +29,7 @@ module Guard
         message = guard_message(test_count, assertion_count, failure_count, error_count, skip_count, duration)
         image   = guard_image(failure_count + error_count, skip_count)
 
-        ::Guard::Notifier.notify(message, title: 'Minitest results', image: image)
+        Compat::UI.notify(message, title: 'Minitest results', image: image)
       end
 
     end

--- a/lib/guard/minitest/notifier.rb
+++ b/lib/guard/minitest/notifier.rb
@@ -1,5 +1,5 @@
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Notifier
 
       def self.guard_message(test_count, assertion_count, failure_count, error_count, skip_count, duration)

--- a/lib/guard/minitest/reporter.rb
+++ b/lib/guard/minitest/reporter.rb
@@ -2,7 +2,7 @@ require 'minitest'
 require 'guard/minitest/notifier'
 
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Reporter < ::Minitest::StatisticsReporter
 
       def report

--- a/lib/guard/minitest/reporters/old_reporter.rb
+++ b/lib/guard/minitest/reporters/old_reporter.rb
@@ -2,7 +2,7 @@ require 'minitest'
 require 'guard/minitest/notifier'
 
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Reporter < ::Minitest::Reporter
 
       def report

--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -35,14 +35,14 @@ module Guard
         return unless options[:all] || !paths.empty?
 
         message = "Running: #{options[:all] ? 'all tests' : paths.join(' ')}"
-        UI.info message, reset: true
+        Compat::UI.info message, reset: true
 
         status = _run_command(paths, options[:all])
 
         # When using zeus or spring, the Guard::Minitest::Reporter can't be used because the minitests run in another
         # process, but we can use the exit status of the client process to distinguish between :success and :failed.
         if zeus? || spring?
-          ::Guard::Notifier.notify(message, title: 'Minitest results', image: status ? :success : :failed)
+          Compat::UI.notify(message, title: 'Minitest results', image: status ? :success : :failed)
         end
 
         if @options[:all_after_pass] && status && !options[:all]
@@ -242,7 +242,7 @@ module Guard
             final_value << " #{value}" unless [TrueClass, FalseClass].include?(value.class)
             cli_options << final_value
 
-            UI.info %{DEPRECATION WARNING: The :#{key} option is deprecated. Pass standard command line argument "--#{key}" to Minitest with the :cli option.}
+            Compat::UI.info %{DEPRECATION WARNING: The :#{key} option is deprecated. Pass standard command line argument "--#{key}" to Minitest with the :cli option.}
           end
         end
       end

--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -1,7 +1,7 @@
 require 'guard/minitest/inspector'
 
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Runner
       attr_accessor :inspector
 

--- a/lib/guard/minitest/utils.rb
+++ b/lib/guard/minitest/utils.rb
@@ -1,7 +1,7 @@
 require 'rubygems/requirement'
 
 module Guard
-  class Minitest
+  class Minitest < Plugin
     class Utils
 
       def self.minitest_version

--- a/spec/lib/guard/minitest/inspector_spec.rb
+++ b/spec/lib/guard/minitest/inspector_spec.rb
@@ -1,3 +1,5 @@
+require 'guard/minitest/inspector'
+
 RSpec.describe Guard::Minitest::Inspector do
   let(:inspector) { Guard::Minitest::Inspector.new(%w[test spec], %w[*_test.rb test_*.rb *_spec.rb]) }
 

--- a/spec/lib/guard/minitest/notifier_spec.rb
+++ b/spec/lib/guard/minitest/notifier_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Guard::Minitest::Notifier do
 
   describe '.notify' do
     it 'should call Guard::Notifier' do
-      allow(::Guard::Notifier).to receive(:notify).with(
+      allow(Guard::Compat::UI).to receive(:notify).with(
         "1 tests\n2 assertions, 0 failures, 0 errors\n\n0.10 tests/s, 0.20 assertions/s\n\nFinished in 10.0000 seconds",
         title: 'Minitest results',
         image: :success

--- a/spec/lib/guard/minitest/runner_spec.rb
+++ b/spec/lib/guard/minitest/runner_spec.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require 'guard/minitest/runner'
+require 'guard/minitest/utils'
 
 RSpec.describe Guard::Minitest::Runner do
   subject { Guard::Minitest::Runner }

--- a/spec/lib/guard/minitest/runner_spec.rb
+++ b/spec/lib/guard/minitest/runner_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Guard::Minitest::Runner do
   before do
     @old_runner = Guard::Minitest::Utils.minitest_version_gte_5? ? '' : " #{File.expand_path('../../../../../lib/guard/minitest/runners/old_runner.rb', __FILE__)}"
     @require_old_runner = Guard::Minitest::Utils.minitest_version_gte_5? ? '' : " -r#{@old_runner}"
+    allow(Guard::Compat::UI).to receive(:notify)
   end
 
   describe 'options' do
@@ -23,7 +24,7 @@ RSpec.describe Guard::Minitest::Runner do
     describe 'deprecated options' do
       describe 'seed' do
         it 'sets cli options' do
-          expect(Guard::UI).to receive(:info).with('DEPRECATION WARNING: The :seed option is deprecated. Pass standard command line argument "--seed" to Minitest with the :cli option.')
+          expect(Guard::Compat::UI).to receive(:info).with('DEPRECATION WARNING: The :seed option is deprecated. Pass standard command line argument "--seed" to Minitest with the :cli option.')
 
           expect(subject.new(seed: 123456789).send(:cli_options)).to eq ['--seed 123456789']
         end
@@ -31,7 +32,7 @@ RSpec.describe Guard::Minitest::Runner do
 
       describe 'verbose' do
         it 'sets cli options' do
-          expect(Guard::UI).to receive(:info).with('DEPRECATION WARNING: The :verbose option is deprecated. Pass standard command line argument "--verbose" to Minitest with the :cli option.')
+          expect(Guard::Compat::UI).to receive(:info).with('DEPRECATION WARNING: The :verbose option is deprecated. Pass standard command line argument "--verbose" to Minitest with the :cli option.')
 
           expect(subject.new(verbose: true).send(:cli_options)).to eq ['--verbose']
         end
@@ -234,7 +235,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs without bundler and rubygems' do
         runner = subject.new
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with(
           "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
         )
@@ -245,7 +246,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs without bundler but rubygems' do
         runner = subject.new(rubygems: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with(
           "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
         )
@@ -263,7 +264,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'should run with bundler but not rubygems' do
         runner = subject.new(bundler: true, rubygems: false)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with(
           "bundle exec ruby -I\"test\" -I\"spec\" -r bundler/setup -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
         )
@@ -274,7 +275,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs without bundler but rubygems' do
         runner = subject.new(bundler: false, rubygems: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with(
           "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
         )
@@ -285,7 +286,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs without bundler and rubygems' do
         runner = subject.new(bundler: false, rubygems: false)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with(
           "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
         )
@@ -328,7 +329,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with default zeus command' do
         runner = subject.new(zeus: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with('zeus test ./test/test_minitest.rb')
 
         runner.run(['test/test_minitest.rb'])
@@ -337,7 +338,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with custom zeus command' do
         runner = subject.new(zeus: 'abcxyz')
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with('zeus abcxyz ./test/test_minitest.rb')
 
         runner.run(['test/test_minitest.rb'])
@@ -348,7 +349,7 @@ RSpec.describe Guard::Minitest::Runner do
           runner = subject.new(zeus: true)
 
           expect(runner).to receive(:system).with('zeus test ./test/test_minitest.rb').and_return(true)
-          expect(Guard::Notifier).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :success)
+          expect(Guard::Compat::UI).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :success)
 
           runner.run(['test/test_minitest.rb'])
         end
@@ -357,7 +358,7 @@ RSpec.describe Guard::Minitest::Runner do
           runner = subject.new(zeus: true)
 
           expect(runner).to receive(:system).with('zeus test ./test/test_minitest.rb').and_return(false)
-          expect(Guard::Notifier).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
+          expect(Guard::Compat::UI).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
 
           runner.run(['test/test_minitest.rb'])
         end
@@ -368,7 +369,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with default spring command' do
         runner = subject.new(spring: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with("bin/rake test test/test_minitest.rb")
 
         runner.run(['test/test_minitest.rb'])
@@ -377,7 +378,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with a clean environment' do
         runner = subject.new(spring: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(Bundler).to receive(:with_clean_env).and_yield
         expect(runner).to receive(:system).with("bin/rake test test/test_minitest.rb")
 
@@ -387,7 +388,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with custom spring command' do
         runner = subject.new(spring: 'spring rake test')
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with("spring rake test test/test_minitest.rb")
 
         runner.run(['test/test_minitest.rb'])
@@ -396,7 +397,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs default spring command with cli' do
         runner = subject.new(spring: true, cli: '--seed 12345 --verbose')
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with("bin/rake test test/test_minitest.rb -- --seed 12345 --verbose")
 
         runner.run(['test/test_minitest.rb'])
@@ -405,7 +406,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs custom spring command with cli' do
         runner = subject.new(spring: 'spring rake test', cli: '--seed 12345 --verbose')
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with("spring rake test test/test_minitest.rb -- --seed 12345 --verbose")
 
         runner.run(['test/test_minitest.rb'])
@@ -415,7 +416,7 @@ RSpec.describe Guard::Minitest::Runner do
         runner = subject.new(spring: true)
 
         expect(runner).to receive(:system).with("bin/rake test test/test_minitest.rb").and_return(true)
-        expect(Guard::Notifier).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :success)
+        expect(Guard::Compat::UI).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :success)
 
         runner.run(['test/test_minitest.rb'])
       end
@@ -424,7 +425,7 @@ RSpec.describe Guard::Minitest::Runner do
         runner = subject.new(spring: true)
 
         expect(runner).to receive(:system).with("bin/rake test test/test_minitest.rb").and_return(false)
-        expect(Guard::Notifier).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
+        expect(Guard::Compat::UI).to receive(:notify).with('Running: test/test_minitest.rb', title: 'Minitest results', image: :failed)
 
         runner.run(['test/test_minitest.rb'])
       end
@@ -434,7 +435,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'should run with drb' do
         runner = subject.new(drb: true)
 
-        expect(Guard::UI).to receive(:info)
+        expect(Guard::Compat::UI).to receive(:info)
         expect(runner).to receive(:system).with('testdrb ./test/test_minitest.rb')
 
         runner.run(['test/test_minitest.rb'])

--- a/spec/lib/guard/minitest_spec.rb
+++ b/spec/lib/guard/minitest_spec.rb
@@ -1,3 +1,5 @@
+require 'guard/minitest'
+
 RSpec.describe Guard::Minitest do
   subject { Guard::Minitest }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,6 @@ RSpec.configure do |config|
   end
 
   config.before do
-    allow(Guard::UI).to receive(:info)
+    allow(Guard::Compat::UI).to receive(:info)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,7 @@ if ENV['CI']
   end
 end
 
-require 'guard/notifier'
 require 'guard/compat/test/helper'
-require 'guard/minitest'
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
- remove dependency on Guard (rely on Guard::Compat)
- rework gem deps
- fix specs (requires)
- use Guard::Compat API instead of Guard API