### PR TITLE
Add guard dependency

### DIFF
--- a/guard-minitest.gemspec
+++ b/guard-minitest.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
+  s.add_runtime_dependency 'guard'
   s.add_runtime_dependency 'guard-compat', '~> 1.2'
   s.add_runtime_dependency 'minitest', '>= 3.0'
 


### PR DESCRIPTION
Guard is not a dependency, so we will get a load error if only guard-minitest is added in Gemfile