### PR TITLE
Fix plugin auto-loading by adding a --guard flag

### DIFF
--- a/lib/guard/minitest/runner.rb
+++ b/lib/guard/minitest/runner.rb
@@ -193,6 +193,7 @@ module Guard
         cmd_parts << '-e ""'
 
         cmd_parts << '--'
+        cmd_parts << '--guard'
         cmd_parts += cli_options
         cmd_parts
       end

--- a/lib/minitest/guard_minitest_plugin.rb
+++ b/lib/minitest/guard_minitest_plugin.rb
@@ -1,19 +1,24 @@
-require 'guard/minitest/utils'
-
-# Require guard unless we're using guard-minitest to test a guard plugin
-require 'guard' unless Dir['guard-*.gemspec'].any?
-
-if ::Guard::Minitest::Utils.minitest_version_gte_5_0_4?
-  require 'guard/minitest/reporter'
-else
-  require 'guard/minitest/reporters/old_reporter'
-end
-
 module Minitest
-  def self.plugin_guard_minitest_options(_opts, _options) # :nodoc:
+  def self.plugin_guard_minitest_options(opts, options) # :nodoc:
+    opts.on '--guard', 'Run with guard plugin enabled' do
+      options[:guard] = true
+    end
   end
 
-  def self.plugin_guard_minitest_init(_options) # :nodoc:
+  def self.plugin_guard_minitest_init(options) # :nodoc:
+    return unless options[:guard]
+
+    require 'guard/minitest/utils'
+
+    # Require guard unless we're using guard-minitest to test a guard plugin
+    require 'guard' unless Dir['guard-*.gemspec'].any?
+
+    if ::Guard::Minitest::Utils.minitest_version_gte_5_0_4?
+      require 'guard/minitest/reporter'
+    else
+      require 'guard/minitest/reporters/old_reporter'
+    end
+
     reporter << ::Guard::Minitest::Reporter.new
   end
 end

--- a/spec/lib/guard/minitest/runner_spec.rb
+++ b/spec/lib/guard/minitest/runner_spec.rb
@@ -188,7 +188,7 @@ RSpec.describe Guard::Minitest::Runner do
       end
 
       it 'outputs command' do
-        expect(Guard::Compat::UI).to receive(:debug).with("Running: ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --")
+        expect(Guard::Compat::UI).to receive(:debug).with("Running: ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard")
         subject.run(['test/test_minitest.rb'])
       end
     end
@@ -200,7 +200,7 @@ RSpec.describe Guard::Minitest::Runner do
       end
 
       it 'shows an error' do
-        expect(Guard::Compat::UI).to receive(:error).with("No such file or directory - ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --")
+        expect(Guard::Compat::UI).to receive(:error).with("No such file or directory - ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard")
         catch(:task_has_failed) { subject.run(['test/test_minitest.rb']) }
       end
 
@@ -214,7 +214,7 @@ RSpec.describe Guard::Minitest::Runner do
 
       it 'passes :cli arguments' do
         expect(Kernel).to receive(:system).with(
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --seed 12345 --verbose"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard --seed 12345 --verbose"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'])
@@ -225,7 +225,7 @@ RSpec.describe Guard::Minitest::Runner do
       let(:options) { { include: %w(lib app) } }
       it 'runs with specified directories included' do
         expect(Kernel).to receive(:system).with(
-          "ruby -I\"test\" -I\"spec\" -I\"lib\" -I\"app\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -I\"lib\" -I\"app\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'])
@@ -237,7 +237,7 @@ RSpec.describe Guard::Minitest::Runner do
 
       it 'does not require minitest/autorun' do
         expect(Kernel).to receive(:system).with(
-          "ruby -I\"test\" -I\"spec\" -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'])
@@ -249,7 +249,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'sets env via all_env if running the full suite' do
         expect(Kernel).to receive(:system).with(
           { 'TESTS_ALL' => 'true' },
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'], all: true)
@@ -261,7 +261,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'allows string setting of all_env' do
         expect(Kernel).to receive(:system).with(
           { 'TESTS_ALL' => 'true' },
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'], all: true)
@@ -273,7 +273,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs with the specified environment' do
         expect(Kernel).to receive(:system).with(
           { 'MINITEST_TEST' => 'test' },
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'])
@@ -285,7 +285,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'merges the specified environment' do
         expect(Kernel).to receive(:system).with(
           { 'MINITEST_TEST' => 'all', 'MINITEST' => 'true' },
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'], all: true)
@@ -300,7 +300,7 @@ RSpec.describe Guard::Minitest::Runner do
       it 'runs without bundler and rubygems' do
         expect(Guard::Compat::UI).to receive(:info)
         expect(Kernel).to receive(:system).with(
-          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+          "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
         ) { system('true') }
 
         subject.run(['test/test_minitest.rb'])
@@ -311,7 +311,7 @@ RSpec.describe Guard::Minitest::Runner do
         it 'runs without bundler but rubygems' do
           expect(Guard::Compat::UI).to receive(:info)
           expect(Kernel).to receive(:system).with(
-            "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+            "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
           ) { system('true') }
 
           subject.run(['test/test_minitest.rb'])
@@ -329,7 +329,7 @@ RSpec.describe Guard::Minitest::Runner do
         it 'runs with bundler' do
           expect(Guard::Compat::UI).to receive(:info)
           expect(Kernel).to receive(:system).with(
-            "bundle exec ruby -I\"test\" -I\"spec\" -r bundler/setup -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+            "bundle exec ruby -I\"test\" -I\"spec\" -r bundler/setup -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
           ) { system('true') }
 
           subject.run(['test/test_minitest.rb'])
@@ -341,7 +341,7 @@ RSpec.describe Guard::Minitest::Runner do
         it 'runs without bundler' do
           expect(Guard::Compat::UI).to receive(:info)
           expect(Kernel).to receive(:system).with(
-            "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+            "ruby -I\"test\" -I\"spec\" -r rubygems -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
           ) { system('true') }
 
           subject.run(['test/test_minitest.rb'])
@@ -353,7 +353,7 @@ RSpec.describe Guard::Minitest::Runner do
         it 'runs without bundler' do
           expect(Guard::Compat::UI).to receive(:info)
           expect(Kernel).to receive(:system).with(
-            "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" --"
+            "ruby -I\"test\" -I\"spec\" -r minitest/autorun -r ./test/test_minitest.rb#{@require_old_runner} -e \"\" -- --guard"
           ) { system('true') }
 
           subject.run(['test/test_minitest.rb'])
@@ -526,10 +526,18 @@ RSpec.describe Guard::Minitest::Runner do
 
       it 'still runs all if requested' do
         expect(Kernel).to receive(:system)
-          .with("ruby -I\"test\" -I\"spec\" -r minitest/autorun#{@require_old_runner} -e \"\" --") { system('true') }
+          .with("ruby -I\"test\" -I\"spec\" -r minitest/autorun#{@require_old_runner} -e \"\" -- --guard") { system('true') }
 
         expect(subject.run([], all: true)).to eq true
       end
+    end
+
+    it 'includes the --guard flag to signal minitest to load the plugin' do
+      expect(Kernel).to receive(:system).with(
+        a_string_starting_with('ruby').and(a_string_including('-- --guard'))
+      ) { system('true') }
+
+      subject.run(['test/test_minitest.rb'])
     end
   end
 


### PR DESCRIPTION
This is a fix for #137.

Minitest loads all plugins regardless of context and this caused guard notifiers to fire even when tests were run outside of guard. To fix this we pass a `--guard` flag to minitest and only add the
`Guard::Minitest::Reporter` if the flag is set.

Also the loading of guard related code is deferred and controlled by the `--guard` flag. This way guard and everything that comes with it will not be loaded outside of guard.

Thanks @zenspider for the inspiration.