### PR TITLE
Update watch to work with latest Rails conventions

### DIFF
--- a/lib/guard/minitest/templates/Guardfile
+++ b/lib/guard/minitest/templates/Guardfile
@@ -1,5 +1,6 @@
 guard :minitest do
   # with Minitest::Unit
+  watch(%r{^test/(.*)\/?_test(.*)\.rb$})
   watch(%r{^test/(.*)\/?test_(.*)\.rb$})
   watch(%r{^lib/(.*/)?([^/]+)\.rb$})     { |m| "test/#{m[1]}test_#{m[2]}.rb" }
   watch(%r{^test/test_helper\.rb$})      { 'test' }


### PR DESCRIPTION
Update watch with new Rails test naming pattern `*_test.rb`, as Rails 5 generators don't use `test_*.rb` anymore.